### PR TITLE
docs: document github pages mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ generated catalogs from internal build profiles.
 
 ## Release Channels
 
+- Documentation mirror: `https://atlassian.github.io/twg-cli/`
 - Stable installer: `https://teamwork-graph.atlassian.com/cli/install`
 - Stable manifest: `https://teamwork-graph.atlassian.com/cli/manifest.json`
 - Release notes: `https://teamwork-graph.atlassian.com/cli/CHANGELOG.md`

--- a/docs/release-integration.md
+++ b/docs/release-integration.md
@@ -21,24 +21,21 @@ release-ready information that is safe for users:
 - public skills and plugin package notes
 - public issue and support links
 
-## Future GitHub Pages Migration
+## GitHub Pages Mirror
 
-Today, GitHub Pages for TWG CLI docs is attached to `atlassian/homebrew-twg`.
-Moving Pages publishing to this repo is a future migration and requires explicit
-approval.
+GitHub Pages for TWG CLI docs is published from this repo:
 
-When that migration happens, update the private `twg-cli` publishing flow in the
-same change:
+- Pages URL: `https://atlassian.github.io/twg-cli/`
+- Source repo: `atlassian/twg-cli`
+- Source branch: `gh-pages`
 
-- Change the GitHub Pages publish target from `atlassian/homebrew-twg` to the
-  Atlassian-owned TWG CLI public repo.
-- Keep `atlassian/homebrew-twg` focused on the Homebrew formula only.
-- Update public docs links that currently assume `/homebrew-twg/`.
-- Verify the GitHub Pages source branch and repo settings before switching the
-  private release pipeline.
-- Keep the publish path token-safe and avoid token-bearing remote URLs.
-- After the switch, DAC docs updates and release docs updates should publish to
-  the dedicated TWG CLI repo, not the Homebrew tap.
+The Homebrew tap repo, `atlassian/homebrew-twg`, owns only the generated
+Homebrew formula. It is not the documentation mirror.
+
+The private `twg-cli` publishing flow should keep the GitHub Pages publish
+target pointed at `atlassian/twg-cli`, use a dedicated `GITHUB_PAGES_TOKEN`, and
+avoid token-bearing remote URLs. That token needs **Contents: read and write**
+and **Pages: read-only** on `atlassian/twg-cli`.
 
 ## Manual Public Repo Update Checklist
 


### PR DESCRIPTION
## Summary

<!-- What changed? -->

## Public Safety Checklist

- [x] No tokens, credentials, cookies, auth files, or `.env` files.
- [x] No private Jira, Confluence, Bitbucket, infrastructure, pipeline, or customer URLs.
- [x] No customer data, proprietary content, or internal runbook detail.
- [x] Generated docs/skills/plugins came from the release/public profile.
- [x] Plugin or release metadata points to public TWG CLI docs and public CDN URLs.

## Verification

<!-- Commands run, preview links, or review notes. -->
